### PR TITLE
Labels: Make API endpoint accept multiple images per request

### DIFF
--- a/service/app.py
+++ b/service/app.py
@@ -9,7 +9,7 @@ from local_processor import LocalImageProcessor
 from ollama_processor import OllamaImageProcessor
 from api import ApiResponse, Caption, Model, Text
 from processor import ImageProcessor
-from utils import decode_image, load_image
+from utils import decode_image, decode_images, load_image
 
 logging.basicConfig(
     level=logging.INFO,
@@ -99,7 +99,7 @@ def process_image_labels(model_name: str, model_version: str) -> tuple[Response,
         if data.get('url'):
             images = [load_image(data['url'])]
         elif data.get('images'):
-            images = decode_image(data['images'])
+            images = decode_images(data['images'])
 
         if not images:
             return create_response({'error': "images or url missing"}, HTTPStatus.BAD_REQUEST)

--- a/service/utils.py
+++ b/service/utils.py
@@ -17,3 +17,10 @@ def decode_image(base64image: str) -> ImageType:
         return Image.open(io.BytesIO(base64.b64decode(image_data)))
     else:
         raise ValueError('Invalid base64 image format')
+
+def decode_images(base64image_list: list[str]) -> list[ImageType]:
+    ret = []
+    for base64image in base64image_list:
+        ret.append(decode_image(base64image))
+
+    return ret


### PR DESCRIPTION
### Description

<!--
We appreciate your interest in contributing! Please provide a brief description of your changes so that we know what is included in this pull request, and confirm that it meets the acceptance criteria:

What does it aim to implement, fix or improve? Why?
-->

Photoprism calls the labels API endpoint with an array of images, seemingly 3 different crops. This PR introduces a function called `decode_images` that decodes all images, and doesn't just raise an exception.

I'm running `photoprism:latest` with the following `vision.yaml`:

```
Models:
- Type: labels
  Resolution: 224
  Service:
    Uri: http://host.docker.internal:5000/api/v1/vision/labels
    FileScheme: data
    RequestFormat: vision
    ResponseFormat: vision
  Tags:
  - vision
- Type: nsfw
  Name: Nsfw
  Resolution: 224
  Tags:
  - serve
- Type: face
  Name: FaceNet
  Resolution: 160
  Tags:
  - serve
- Type: caption
  Resolution: 224
  Service:
    Uri: http://host.docker.internal:5000/api/v1/vision/caption
    FileScheme: data
    RequestFormat: vision
    ResponseFormat: vision
  Tags:
  - vision
Thresholds:
  Confidence: 10
```

#### Related Issues

- Links to issues that this PR fixes, implements, or is otherwise related to...

### Acceptance Criteria

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [ ] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [ ] Documentation has been / will be updated, especially as it relates to new configuration options or potentially disruptive changes

---
<details>

<summary>Contribution Agreement</summary>

When contributing code or other intellectual property for the first time, we ask that you read and agree to the following so that we can safely use it in all of our projects without risking unexpected legal disputes or having to repeatedly ask for permission:

- [x] I grant PhotoPrism a non-exclusive, perpetual, irrevocable, worldwide, fully-paid, royalty-free, and transferable right to use, copy, modify, merge, publish, distribute, sublicense and/or sell my Contributions without any restrictions. This includes a non-exclusive, perpetual, irrevocable, worldwide, fully-paid, royalty-free, and transferable patent license to use, offer for sale, sell, import, export, and otherwise transfer or make available my Contributions. PhotoPrism may, in its sole discretion, apply any license to my Contributions that it deems appropriate for the particular purpose, including other open source, copyleft, and proprietary licenses. PhotoPrism may assign this Agreement and all of its rights, obligations and licenses hereunder.
- [x] I confirm that I am the sole author of this Contribution and am legally authorized to grant the above licenses and waivers with respect to this Contribution and any other of my Contributions. If your Contributions were created in the course of your employment with your former or current employer, you represent that this employer has authorized you to make your Contributions on its behalf or has waived all rights, claims, or interests in your Contributions.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

This agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

**Thank you very much!** 🌈💎✨
</details>
