### PR TITLE
API: Specify custom prompts for labels and NSFW endpoints

### DIFF
--- a/service/app.py
+++ b/service/app.py
@@ -102,6 +102,7 @@ def process_image_caption(model_name: str, model_version: str) -> tuple[Response
 def process_image_labels(model_name: str, model_version: str) -> tuple[Response, int]:
     try:
         data = request.get_json() if request.is_json else request.args
+        prompt = parse_prompt_from_request()
         images = []
         if data.get('url'):
             images = [load_image(data['url'])]
@@ -113,7 +114,7 @@ def process_image_labels(model_name: str, model_version: str) -> tuple[Response,
 
         for processor in image_processors:
             if processor.can_process(model_name, model_version):
-                status, result = processor.generate_labels(model_name, model_version, images)
+                status, result = processor.generate_labels(model_name, model_version, images, prompt)
                 if status == 'ok':
                     response_data = ApiResponse(
                         id=data.get('id', str(uuid.uuid4())),
@@ -135,12 +136,13 @@ def process_image_labels(model_name: str, model_version: str) -> tuple[Response,
 def detect_nsfw(model_name: str, model_version: str) -> tuple[Response, int]:
     try:
         data, image = parse_image_from_request()
+        prompt = parse_prompt_from_request()
         if not image:
             return create_response({'error': "image or url missing"}, HTTPStatus.BAD_REQUEST)
 
         for processor in image_processors:
             if processor.can_process(model_name, model_version):
-                status, result = processor.detect_nsfw(model_name, model_version, image)
+                status, result = processor.detect_nsfw(model_name, model_version, image, prompt)
                 if status == 'ok':
                     response_data = ApiResponse(
                         id=data.get('id', str(uuid.uuid4())),

--- a/service/local_processor.py
+++ b/service/local_processor.py
@@ -375,12 +375,12 @@ class LocalImageProcessor(ImageProcessor):
         return processor.generate_caption(image, prompt)
 
     @override
-    def generate_labels(self, model_name: str, model_version: str, images: list[Image]) -> tuple[str, Labels | str]:
+    def generate_labels(self, model_name: str, model_version: str, images: list[Image], prompt: str) -> tuple[str, Labels | str]:
         # TODO: Implement label generation for local models
         return 'error', 'Local model does not support label generation yet. Use the Ollama API instead.'
 
     @override
-    def detect_nsfw(self, model_name: str, model_version: str, image: Image) -> tuple[str, NSFW | str]:
+    def detect_nsfw(self, model_name: str, model_version: str, image: Image, prompt) -> tuple[str, NSFW | str]:
         """Detect NSFW content in the image using the specified model."""
         processor = self.get_processor(model_name)
         if isinstance(processor, NSFWImageProcessor):

--- a/service/ollama_processor.py
+++ b/service/ollama_processor.py
@@ -42,9 +42,13 @@ class OllamaImageProcessor(ImageProcessor):
         return self._generate_with_prompt(model_name, model_version, [image], prompt)
 
     @override
-    def generate_labels(self, model_name: str, model_version: str, images: list[Image]) -> tuple[str, Labels | str]:
+    def generate_labels(self, model_name: str, model_version: str, images: list[Image], prompt) -> tuple[str, Labels | str]:
         schema = Labels.model_json_schema()
-        status, result = self._generate_with_prompt(model_name, model_version, images, labels_prompt, schema=schema)
+
+        if prompt == '' or prompt == 'default':
+            prompt = labels_prompt
+
+        status, result = self._generate_with_prompt(model_name, model_version, images, prompt, schema=schema)
         if status == 'ok':
             try:
                 labels = Labels.model_validate_json(result)
@@ -54,12 +58,17 @@ class OllamaImageProcessor(ImageProcessor):
         return status, result
 
     @override
-    def detect_nsfw(self, model_name: str, model_version: str, images: Image) -> tuple[str, NSFW | str]:
+    def detect_nsfw(self, model_name: str, model_version: str, images: Image, prompt) -> tuple[str, NSFW | str]:
         """
         Tries to detect if the image is NSFW. Accurate detection is not guaranteed.
         """
+
         schema = NSFW.model_json_schema()
-        status, result = self._generate_with_prompt(model_name, model_version, [images], nsfw_prompt, schema=schema)
+
+        if prompt == '' or prompt == 'default':
+            prompt = nsfw_prompt
+    
+        status, result = self._generate_with_prompt(model_name, model_version, [images], prompt, schema=schema)
         if status == 'ok':
             try:
                 probabilities = NSFW.model_validate_json(result)

--- a/service/processor.py
+++ b/service/processor.py
@@ -21,7 +21,7 @@ class ImageProcessor(ABC):
         pass
 
     @abstractmethod
-    def generate_labels(self, model_name: str, model_version: str, images: list[Image]) -> tuple[str, Labels | str]:
+    def generate_labels(self, model_name: str, model_version: str, images: list[Image], prompt: str) -> tuple[str, Labels | str]:
         """
         :param model_name: name of the requested model
         :param model_version: version of the requested model
@@ -30,7 +30,7 @@ class ImageProcessor(ABC):
         pass
 
     @abstractmethod
-    def detect_nsfw(self, model_name: str, model_version: str, image: Image) -> tuple[str, NSFW | str]:
+    def detect_nsfw(self, model_name: str, model_version: str, image: Image, prompt) -> tuple[str, NSFW | str]:
         """
         :param model_name: name of the requested model
         :param model_version: version of the requested model


### PR DESCRIPTION
### Description

These changes implement passing custom prompts to models as shown in the README for all endpoints.

#### Related Issues

[Vision Service: Improve caption prompt and allow submitting a custom prompt with the request data](https://github.com/photoprism/photoprism-vision/issues/11)

### Acceptance Criteria

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [N/A ] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [x] Documentation has been / will be updated, especially as it relates to new configuration options or potentially disruptive changes

---
<details>

<summary>Contribution Agreement</summary>

When contributing code or other intellectual property for the first time, we ask that you read and agree to the following so that we can safely use it in all of our projects without risking unexpected legal disputes or having to repeatedly ask for permission:

- [x] I grant PhotoPrism a non-exclusive, perpetual, irrevocable, worldwide, fully-paid, royalty-free, and transferable right to use, copy, modify, merge, publish, distribute, sublicense and/or sell my Contributions without any restrictions. This includes a non-exclusive, perpetual, irrevocable, worldwide, fully-paid, royalty-free, and transferable patent license to use, offer for sale, sell, import, export, and otherwise transfer or make available my Contributions. PhotoPrism may, in its sole discretion, apply any license to my Contributions that it deems appropriate for the particular purpose, including other open source, copyleft, and proprietary licenses. PhotoPrism may assign this Agreement and all of its rights, obligations and licenses hereunder.
- [x] I confirm that I am the sole author of this Contribution and am legally authorized to grant the above licenses and waivers with respect to this Contribution and any other of my Contributions. If your Contributions were created in the course of your employment with your former or current employer, you represent that this employer has authorized you to make your Contributions on its behalf or has waived all rights, claims, or interests in your Contributions.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

This agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

**Thank you very much!** 🌈💎✨
</details>
