### PR TITLE
#16 Fixed gosu call if container is started as defined user

### DIFF
--- a/service/scripts/entrypoint.sh
+++ b/service/scripts/entrypoint.sh
@@ -4,11 +4,11 @@
 
 . ./venv/bin/activate
 
-if [ ! -z "$PHOTOPRISM_UID" ]; then
-  echo "Switching to user id $PHOTOPRISM_UID..."
+if [[ ! -z "$PHOTOPRISM_UID" && $(id -u) -eq 0 ]]; then
+  echo "Switching from $(whoami) ($(id -u)) to user id $PHOTOPRISM_UID..."
   exec gosu $PHOTOPRISM_UID gunicorn "$@"
 else
-  # Run as default user
+  echo "Running as default user $(whoami) ($(id -u))..."
   exec gunicorn "$@"
 fi
 


### PR DESCRIPTION
- f.e. if compose.yml contains user: 1000:1000, it is not possible to switch user

- we can switch only from root user

### Description

Improved handling of user id in entrypoint.sh.

Now it tries to switch user only if root is executing startup script.

#### Related Issues

Fixed  #16 

### Acceptance Criteria

- [ ] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [ ] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [ ] Documentation has been / will be updated, especially as it relates to new configuration options or potentially disruptive changes

---
<details>

<summary>Contribution Agreement</summary>

When contributing code or other intellectual property for the first time, we ask that you read and agree to the following so that we can safely use it in all of our projects without risking unexpected legal disputes or having to repeatedly ask for permission:

- [x] I grant PhotoPrism a non-exclusive, perpetual, irrevocable, worldwide, fully-paid, royalty-free, and transferable right to use, copy, modify, merge, publish, distribute, sublicense and/or sell my Contributions without any restrictions. This includes a non-exclusive, perpetual, irrevocable, worldwide, fully-paid, royalty-free, and transferable patent license to use, offer for sale, sell, import, export, and otherwise transfer or make available my Contributions. PhotoPrism may, in its sole discretion, apply any license to my Contributions that it deems appropriate for the particular purpose, including other open source, copyleft, and proprietary licenses. PhotoPrism may assign this Agreement and all of its rights, obligations and licenses hereunder.
- [x] I confirm that I am the sole author of this Contribution and am legally authorized to grant the above licenses and waivers with respect to this Contribution and any other of my Contributions. If your Contributions were created in the course of your employment with your former or current employer, you represent that this employer has authorized you to make your Contributions on its behalf or has waived all rights, claims, or interests in your Contributions.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

This agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

**Thank you very much!** 🌈💎✨
</details>
